### PR TITLE
Getting rss url on alert creation

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -24,7 +24,7 @@ function generateCookies(mail, password, cb) {
         if(err) return cb(err);
         const cookies = getCookies();
         cb(null, cookies);
-    });    
+    });
 }
 
 function setCookies(cookies){
@@ -97,7 +97,7 @@ function modify(id, newData, cb) {
     if(!alert) return cb('no alert found');
 
     const createId = alerts.getCreateIdByState(state);
- 
+
     const modifiedAlert = alerts.modifyData(alert, newData, createId);
 
     const requestX = alerts.getRequestXByState(state);
@@ -110,16 +110,17 @@ function modify(id, newData, cb) {
 function create(createData, cb) {
     const requestX = alerts.getRequestXByState(state);
     const createId = alerts.getCreateIdByState(state);
-    
+
     const createParams = alerts.create(createData, createId);
 
     reqHandler.create(requestX, createParams, (err, resp, body) => {
         if(err) return cb(err);
         try {
             const parsedBody = JSON.parse(body);
-            let alert = parsedBody[4][0]; 
+            let alert = parsedBody[4][0];
             const id = alert[1];
-            cb(null, { ...createData, id});
+            const rss = alerts.getRssFeedByCreateResponse(body);
+            cb(null, { ...createData, id, rss});
         }catch(e) {
             cb(e);
         }

--- a/tests/test.js
+++ b/tests/test.js
@@ -55,6 +55,7 @@ describe('google', function () {
                 api.create(alertToCreate, (err, alert) => {
                     expect(err).to.be(null);
                     expect(alert.name).to.be(alertToCreate.name);
+                    expect(alert).to.have.property('rss');
                     done();
                 });
             });


### PR DESCRIPTION
I saw  you had a method to get the RSS feed URL from the creation response body but you were not using it. What I understand on the README documentation is that this is returned when the alert object is created.

I added this field to the created object.